### PR TITLE
Escape text and URL when copying link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,8 @@ browser.contextMenus.onClicked.addListener(({ menuItemId, linkText, linkUrl }, {
     browser.tabs.executeScript(id, { file: "copy.js" });
   } else if (menuItemId === "copy-link-as-markdown") {
     browser.tabs.executeScript(id, { file: "copy-link.js" }).then(() => {
+      linkText = linkText.replace(/[\\\[\]]/g, (match) => '\\'+match);
+      linkUrl = linkUrl.replace(/\\/g, '%5C').replace(/\(/g, '%28').replace(/\)/g, '%29');
       browser.tabs.sendMessage(id, { text: `[${linkText}](${linkUrl})` });
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,8 @@ browser.contextMenus.onClicked.addListener(({ menuItemId, linkText, linkUrl }, {
     browser.tabs.executeScript(id, { file: "copy.js" });
   } else if (menuItemId === "copy-link-as-markdown") {
     browser.tabs.executeScript(id, { file: "copy-link.js" }).then(() => {
-      linkText = linkText.replace(/[\\\[\]]/g, (match) => '\\'+match);
-      linkUrl = linkUrl.replace(/\\/g, '%5C').replace(/\(/g, '%28').replace(/\)/g, '%29');
+      linkText = linkText.replace(/([\\`*_[\]<>])/g, "\\$1");
+      linkUrl = linkUrl.replace(/[\\!'()*]/g, c => `%${c.charCodeAt(0).toString(16)}`);
       browser.tabs.sendMessage(id, { text: `[${linkText}](${linkUrl})` });
     });
   }


### PR DESCRIPTION
Looking at https://github.com/0x6b/copy-selection-as-markdown/pull/33 I noticed that no escaping was performed: [Foo\]](https://example.com/Foo\)) (`<a href="https://example.com/Foo)">Foo]</a>`) is copied as `[Foo]](https://example.com/Foo))` instead of `[Foo\]](https://example.com/Foo%29)`.

Note: I haven't compiled and tested the addon with this change.