### PR TITLE
Support regular expressions in title substitution

### DIFF
--- a/packages/core/src/copy.js
+++ b/packages/core/src/copy.js
@@ -49,7 +49,8 @@ async function main() {
         ? false
         : options.linkWithoutStyling;
     options.img = typeof options.img === "undefined" ? false : options.img;
-    options.embedImage = typeof options.embedImage === "undefined" ? false : options.embedImage;
+    options.embedImage =
+      typeof options.embedImage === "undefined" ? false : options.embedImage;
     options.titleSubstitution =
       typeof options.titleSubstitution === "undefined"
         ? ""
@@ -111,7 +112,7 @@ ${selection.url}
 /* --- end of copy-selection-as-markdown debug information ------------------------------------------------ */
 Open new issue at https://github.com/0x6b/copy-selection-as-markdown/issues/new with information above.
 
-`      );
+`);
     }
     doCopy(text, html);
   } catch (e) {

--- a/packages/core/src/copy.js
+++ b/packages/core/src/copy.js
@@ -1,4 +1,8 @@
-import { doCopy, getSelectionAsMarkdown, convertTitleSubstitution } from "./util";
+import {
+  doCopy,
+  getSelectionAsMarkdown,
+  convertTitleSubstitution,
+} from "./util";
 
 async function main() {
   try {

--- a/packages/core/src/copy.js
+++ b/packages/core/src/copy.js
@@ -1,6 +1,4 @@
-import { doCopy, getSelectionAsMarkdown } from "./util";
-
-const RegexEscape = require("regex-escape");
+import { doCopy, getSelectionAsMarkdown, convertTitleSubstitution } from "./util";
 
 async function main() {
   try {
@@ -63,13 +61,7 @@ async function main() {
 
     let title = document.title;
     if (options.titleSubstitution !== "") {
-      let pattern = new RegExp(
-        options.titleSubstitution
-          .split(/\n/)
-          .map((e) => `(${RegexEscape(e)})`)
-          .join("|"),
-        "g"
-      );
+      let pattern = convertTitleSubstitution(options.titleSubstitution);
       title = title.replace(pattern, "");
     }
     let text = options.linkWithoutStyling

--- a/packages/core/src/settings.html
+++ b/packages/core/src/settings.html
@@ -192,7 +192,7 @@
     </div>
     <div>
         <h2>Advanced</h2>
-        <label for="titleSubstitution">Title Substitution -- line separated texts which will be removed from title text</label>
+        <label for="titleSubstitution">Title Substitution -- line separated texts which will be removed from title text (supports <a href="https://regex101.com/">regular expressions</a> if the line starts and ends with / e.g. <code>/^number:\d$/</code>)</label>
         <textarea id="titleSubstitution" rows="5"></textarea>
         <input type="checkbox" id="embedImage">
         <label for="embedImage">Embed <code>img</code>s (.gif, .jpg, .jpeg, .png, and .webp) as base64 text as possible -- images will be encoded as base64 text, instead of URL, and added at the end of copied text. <strong>Ask for the permission to access all websites when clicking Save button, since sometimes referenced images are hosted other than current active tab so <code>activeTab</code> permission is not sufficient.</strong> Unchecking this removes the additional permission.</label>

--- a/packages/core/src/settings.html
+++ b/packages/core/src/settings.html
@@ -192,7 +192,7 @@
     </div>
     <div>
         <h2>Advanced</h2>
-        <label for="titleSubstitution">Title Substitution -- line separated texts which will be removed from title text (supports <a href="https://regex101.com/">regular expressions</a> if the line starts and ends with / e.g. <code>/^number:\d$/</code>)</label>
+        <label for="titleSubstitution">Title Substitution -- line separated texts which will be removed from title text (supports <a href="https://regex101.com/">regular expressions</a> if the line starts and ends with / e.g. <code>/^number:\d$/</code>. Please escape <code>|</code> with <code>\</code>.)</label>
         <textarea id="titleSubstitution" rows="5"></textarea>
         <input type="checkbox" id="embedImage">
         <label for="embedImage">Embed <code>img</code>s (.gif, .jpg, .jpeg, .png, and .webp) as base64 text as possible -- images will be encoded as base64 text, instead of URL, and added at the end of copied text. <strong>Ask for the permission to access all websites when clicking Save button, since sometimes referenced images are hosted other than current active tab so <code>activeTab</code> permission is not sufficient.</strong> Unchecking this removes the additional permission.</label>

--- a/packages/core/src/util.js
+++ b/packages/core/src/util.js
@@ -163,13 +163,11 @@ const getSelectionAsMarkdown = async (options) => {
         if (
           img.hasAttribute("src") &&
           img.getAttribute("src").startsWith("http") &&
-          (
-            img.getAttribute("src").split("?", 2)[0].endsWith("gif") ||
+          (img.getAttribute("src").split("?", 2)[0].endsWith("gif") ||
             img.getAttribute("src").split("?", 2)[0].endsWith("jpg") ||
             img.getAttribute("src").split("?", 2)[0].endsWith("jpeg") ||
             img.getAttribute("src").split("?", 2)[0].endsWith("png") ||
-            img.getAttribute("src").split("?", 2)[0].endsWith("webp")
-          )
+            img.getAttribute("src").split("?", 2)[0].endsWith("webp"))
         ) {
           img.setAttribute("src", await imgToDataUrl(img));
         }

--- a/packages/core/src/util.js
+++ b/packages/core/src/util.js
@@ -7,8 +7,19 @@ import turndownPluginLinkWithoutStyling from "./plugins/link-without-styling";
 import turndownPluginListItem from "./plugins/list-item";
 import { tables, taskListItems } from "turndown-plugin-gfm";
 import * as clipboard from "clipboard-polyfill";
+import RegexEscape from "regex-escape";
 
 const url = require("url");
+
+const convertTitleSubstitution = (titleSubstitutionOption = '') => {
+  return new RegExp(
+    titleSubstitutionOption
+      .split(/\n/)
+      .map((e) => `(${RegexEscape(e)})`)
+      .join("|"),
+    "g"
+  );
+}
 
 const getSelectionAsMarkdown = async (options) => {
   let turndownService = TurndownService(options);
@@ -188,4 +199,4 @@ const imgToDataUrl = (image) => {
   });
 };
 
-export { getSelectionAsMarkdown, doCopy };
+export { getSelectionAsMarkdown, doCopy, convertTitleSubstitution };

--- a/packages/core/src/util.js
+++ b/packages/core/src/util.js
@@ -11,15 +11,25 @@ import RegexEscape from "regex-escape";
 
 const url = require("url");
 
-const convertTitleSubstitution = (titleSubstitutionOption = '') => {
+const regexpRegexp = /^\/(.+)\/$/;
+
+const convertTitleSubstitution = (titleSubstitutionOption = "") => {
+  const convertLine = (line) => {
+    if (line.match(regexpRegexp)) {
+      const [, expression] = regexpRegexp.exec(line);
+      return expression;
+    } else {
+      return RegexEscape(line);
+    }
+  };
   return new RegExp(
     titleSubstitutionOption
       .split(/\n/)
-      .map((e) => `(${RegexEscape(e)})`)
+      .map((line) => `(${convertLine(line)})`)
       .join("|"),
     "g"
   );
-}
+};
 
 const getSelectionAsMarkdown = async (options) => {
   let turndownService = TurndownService(options);

--- a/packages/core/test/util.test.js
+++ b/packages/core/test/util.test.js
@@ -15,5 +15,19 @@ describe("util", () => {
         ).toBe(result);
       }
     );
+
+    test.each`
+      title                  | substitutionOption       | result
+      ${"abcd"}              | ${"/[abc]+/"}            | ${"d"}
+      ${"title #1234"}       | ${"/ #\\d+/"}            | ${"title"}
+      ${"second line title"} | ${"first line\n/[^l]+/"} | ${"ll"}
+    `(
+      "provides regex title substitution on $title",
+      ({ title, substitutionOption, result }) => {
+        expect(
+          title.replace(convertTitleSubstitution(substitutionOption), "")
+        ).toBe(result);
+      }
+    );
   });
 });

--- a/packages/core/test/util.test.js
+++ b/packages/core/test/util.test.js
@@ -1,0 +1,19 @@
+import { convertTitleSubstitution } from "../src/util";
+
+describe("util", () => {
+  describe("convertTitleSubstitution", () => {
+    test.each`
+      title                  | substitutionOption           | result
+      ${"abcd"}              | ${"cd"}                      | ${"ab"}
+      ${"/\\^%[]hello"}      | ${"/\\^%[]"}                 | ${"hello"}
+      ${"second line title"} | ${"first line\nsecond line"} | ${" title"}
+    `(
+      "provides string title substitution on $title",
+      ({ title, substitutionOption, result }) => {
+        expect(
+          title.replace(convertTitleSubstitution(substitutionOption), "")
+        ).toBe(result);
+      }
+    );
+  });
+});


### PR DESCRIPTION
This PR is a suggested solution to #68.

There are 3 commits:

- refactoring in preparation for the new feature (doesn't change behaviour)
- implementing the feature
- unrelated changes as a result of running `yarn format`

**reviewing the PR commit by commit might make the review easier**

## Not locally tested

I added unit tests, but I wasn't able to run the extension locally. I followed the `CONTRIBUTING.md`, but the `yarn watch:firefox` task dies on my local with the following error:

```
Applying config files: ./package.json, ./web-ext-config.js, ./web-ext-config.js
Running web extension from /home/tomas/workspace/copy-selection-as-markdown/packages/firefox/dist

a: Could not read manifest.json file at /home/tomas/workspace/copy-selection-as-markdown/packages/firefox/dist/manifest.json: Error: ENOENT: no such file or directory, open '/home/tomas/workspace/copy-selection-as-markdown/packages/firefox/dist/manifest.json'
```

Maybe I've done something silly. This is the first time I work on a Firefox extension.

```sh
❯❯❯ yarn -v                                                                                         
1.22.10
❯❯❯ node -v
v14.15.1
```