### PR TITLE
fix extension loading error in chrome extension

### DIFF
--- a/packages/chromium/manifest.json
+++ b/packages/chromium/manifest.json
@@ -10,12 +10,12 @@
   },
   "background": {
     "scripts": [
-      "index.js",
-      "browser-polyfill.min.js"
+      "dist/index.js",
+      "dist/browser-polyfill.min.js"
     ]
   },
   "options_ui": {
-    "page": "settings.html"
+    "page": "dist/settings.html"
   },
   "browser_action": {
     "browser_style": true,

--- a/packages/chromium/manifest.json
+++ b/packages/chromium/manifest.json
@@ -36,12 +36,14 @@
     }
   },
   "permissions": [
-    "<all_urls>",
     "activeTab",
     "clipboardWrite",
     "contextMenus",
     "tabs",
     "storage"
+  ],
+  "optional_permissions":[
+    "<all_urls>"
   ]
 }
 

--- a/packages/chromium/src/index.js
+++ b/packages/chromium/src/index.js
@@ -14,9 +14,9 @@ browser.contextMenus.create(
 );
 
 browser.contextMenus.onClicked.addListener(() => {
-  browser.tabs.executeScript({ file: "copy.js" });
+  browser.tabs.executeScript({ file: "dist/copy.js" });
 });
 
 browser.browserAction.onClicked.addListener(() =>
-  browser.tabs.executeScript({ file: "copy.js" })
+  browser.tabs.executeScript({ file: "dist/copy.js" })
 );


### PR DESCRIPTION
Hi @0x6b , very thank you for developing this extension, I used it a lot in Firefox.
But after I switch to Brave browser (chrome-based), it's a long waited for its chrome version.
So when I see this extension has been ported to chrome, I can't wait to build it by myself.
I've built it successfully, but I met some error when I loading this extension.
So I try to fix these errors and now it worked perfectly!

This pull request fix these errors, which almost all are path issue,  except the last one, which is permission issue. 

In order to dynamically remove hosts permission, we need to create "optional_permissions" key and move "<all_urls>" into that key. see: https://developer.chrome.com/docs/extensions/reference/permissions/#step-2-declare-optional-permissions-in-the-manifest
