### PR TITLE
fix: preserve image URLs when embedding fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ To change shortcut key, click gear icon on top-right and click **Manage Extensio
 - Title Substitution -- line separated texts which will be removed from title text. (supports [regular expressions](https://regex101.com/) if the line starts and ends with `/` e.g. `/^number:\d$/`. Please escape `|` with `\`.) If you add ` - Mozilla | MDN` to the textbox, the copied text wil be:
   - From `[Add-ons - Mozilla | MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons)`
   - To `[Add-ons](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons)`
-- Embed `img`s (.gif, .jpg, .jpeg, .png, and .webp) as base64 -- images will be encoded as base64 text, instead of URL, and added at the end of copied text. Sometime it might fail but useful for backup. See [Permissions](#privacy).
+- Embed `img`s (.gif, .jpg, .jpeg, .png, and .webp) as base64 when possible -- images will be encoded as base64 text, instead of URL, and added at the end of copied text. Browser and server security restrictions may prevent some images from being embedded; those images keep their original URLs. See [Permissions](#privacy).
 
 ## Contributing
 

--- a/packages/core/src/settings/settings.html
+++ b/packages/core/src/settings/settings.html
@@ -195,7 +195,7 @@
         <label for="titleSubstitution">Title Substitution -- line separated texts which will be removed from title text (supports <a href="https://regex101.com/">regular expressions</a> if the line starts and ends with / e.g. <code>/^number:\d$/</code>. Please escape <code>|</code> with <code>\</code>.)</label>
         <textarea id="titleSubstitution" rows="5"></textarea>
         <input type="checkbox" id="embedImage">
-        <label for="embedImage">Embed <code>img</code>s (.gif, .jpg, .jpeg, .png, and .webp) as base64 text as possible -- images will be encoded as base64 text, instead of URL, and added at the end of copied text. <strong>Ask for the permission to access all websites when clicking Save button, since sometimes referenced images are hosted other than current active tab so <code>activeTab</code> permission is not sufficient.</strong> Unchecking this removes the additional permission.</label>
+        <label for="embedImage">Embed <code>img</code>s (.gif, .jpg, .jpeg, .png, and .webp) as base64 text when possible -- images will be encoded as base64 text, instead of URL, and added at the end of copied text. <strong>This asks for permission to access all websites when clicking Save because referenced images may be hosted outside the current website.</strong> Browser and server security restrictions may prevent some images from being embedded; those images keep their original URLs. Unchecking this removes the additional permission.</label>
     </div>
 
     <button type="submit">Save</button>

--- a/packages/core/src/utils/url-resolver.js
+++ b/packages/core/src/utils/url-resolver.js
@@ -19,20 +19,25 @@ export const resolveRelativeUrls = (container, baseUrl) => {
 
 export const imgToDataUrl = (image) => {
   return new Promise((resolve) => {
+    const originalSrc = image.getAttribute("src");
     const img = new Image();
     img.setAttribute("crossorigin", "anonymous");
     img.onload = function () {
-      let canvas = document.createElement("canvas");
-      canvas.width = this.naturalWidth;
-      canvas.height = this.naturalHeight;
+      try {
+        const canvas = document.createElement("canvas");
+        canvas.width = this.naturalWidth;
+        canvas.height = this.naturalHeight;
 
-      canvas.getContext("2d").drawImage(this, 0, 0);
-      image.setAttribute("src", canvas.toDataURL("image/png"));
+        canvas.getContext("2d").drawImage(this, 0, 0);
+        image.setAttribute("src", canvas.toDataURL("image/png"));
 
-      resolve(image.src);
-      canvas = null;
+        resolve(image.src);
+      } catch {
+        resolve(originalSrc);
+      }
     };
+    img.onerror = () => resolve(originalSrc);
 
-    img.src = image.getAttribute("src");
+    img.src = originalSrc;
   });
 };

--- a/packages/core/test/util.test.js
+++ b/packages/core/test/util.test.js
@@ -1,5 +1,5 @@
 import { convertTitleSubstitution } from "../src/utils/title-substitution";
-import { resolveRelativeUrls } from "../src/utils/url-resolver";
+import { imgToDataUrl, resolveRelativeUrls } from "../src/utils/url-resolver";
 
 describe("util", () => {
   describe("convertTitleSubstitution", () => {
@@ -52,6 +52,27 @@ describe("util", () => {
       expect(container.querySelector("img").getAttribute("src")).toBe(
         "https://example.com/docs/images/example.png"
       );
+    });
+  });
+
+  describe("imgToDataUrl", () => {
+    test("keeps the original URL when the image cannot be loaded", async () => {
+      const OriginalImage = global.Image;
+      global.Image = class {
+        setAttribute() {}
+
+        set src(_value) {
+          this.onerror();
+        }
+      };
+      const image = document.createElement("img");
+      image.src = "https://example.com/cross-origin.png";
+
+      try {
+        await expect(imgToDataUrl(image)).resolves.toBe(image.src);
+      } finally {
+        global.Image = OriginalImage;
+      }
     });
   });
 });

--- a/packages/firefox/manifest.json
+++ b/packages/firefox/manifest.json
@@ -39,7 +39,7 @@
     }
   },
   "permissions": ["activeTab", "clipboardWrite", "contextMenus", "storage", "scripting"],
-  "host_permissions": ["<all_urls>"],
+  "optional_host_permissions": ["<all_urls>"],
   "browser_specific_settings": {
     "gecko": {
       "id": "{db9a72da-7bc5-4805-bcea-da3cb1a15316}"


### PR DESCRIPTION
Request broad website access only when image embedding is enabled.